### PR TITLE
Improvements for 1.6.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,3 +132,23 @@ jobs:
       - run: sleep 120
       - run: ./mcutils query-full localhost 25565
       - run: docker stop test-minecraft-server
+  
+  vanilla-rcon:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - 1.2.5
+          - 1.6.4
+          - 1.7.10
+          - latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} -e RCON_PASSWORD=password --name test-minecraft-server itzg/minecraft-server
+      - run: sleep 120
+      - run: ./mcutils rcon localhost 25575 password "say hello"
+      - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: tests
 
 on: push
 
+env:
+  go-version: stable
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -9,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go test ./...
   
   cli-build-run:
@@ -18,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: ./mcutils version
   
@@ -28,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: ./mcutils version
       # pinging mc.hypixel.net as it is known to work only with SRV lookup enabled and should be up for a long time coming
@@ -49,10 +52,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 60
+      - run: sleep 30
       - run: ./mcutils ping-legacy localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -68,10 +71,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 60
+      - run: sleep 30
       - run: ./mcutils ping-legacy-1.6.4 localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -86,10 +89,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 60
+      - run: sleep 30
       - run: ./mcutils ping localhost 25565
       - run: docker stop test-minecraft-server
 
@@ -106,10 +109,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565/udp -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 60
+      - run: sleep 30
       - run: ./mcutils query-basic localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -126,10 +129,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565/udp -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 60
+      - run: sleep 30
       - run: ./mcutils query-full localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -146,10 +149,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25575:25575 -e VERSION=${{ matrix.version }} -e RCON_PASSWORD=password --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 60
+      - run: sleep 30
       - run: ./mcutils rcon localhost 25575 password "say hello"
       - run: docker stop test-minecraft-server
   
@@ -163,9 +166,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.26.3
+          go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=TRUE -e VERSION=${{ matrix.version }} -p 19132:19132/udp itzg/minecraft-bedrock-server
-      - run: sleep 60
-      - run: ./mcutils bedrock-ping localhost 19132
+      - run: sleep 30
+      - run: ./mcutils ping-bedrock localhost 19132
       - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,57 @@
 name: tests
+
 on: push
+
 jobs:
-  test:
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          go-version: 1.17.3
-      - run: go version
+          go-version: 1.26.3
       - run: go test ./...
-      - run: go build ./cmd/mcutils
+  
+  cli-build-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run: ./mcutils version
+  
+  srv-lookup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run: ./mcutils version
+      # pinging mc.hypixel.net as it is known to work only with SRV lookup enabled and should be up for a long time coming
+      - run: ./mcutils ping mc.hypixel.net 25565
+  
+  vanilla-ping-legacy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - 1.2.5
+          - 1.4.7
+          - 1.5.2
+          - 1.6.4
+          - 1.7.10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
+      - run: sleep 10
+      - run: ./mcutils ping-legacy localhost 25565
+      - run: docker stop test-minecraft-server
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,24 @@ jobs:
         with:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
-      - run: ./mcutils version
-      # pinging mc.hypixel.net as it is known to work only with SRV lookup enabled and should be up for a long time coming
-      - run: ./mcutils ping mc.hypixel.net 25565
+      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=latest --name test-minecraft-server itzg/minecraft-server
+      - run: |
+          sudo apt install dnsmasq -y
+
+          sudo systemctl stop systemd-resolved || true
+          sudo systemctl disable systemd-resolved || true
+          sleep 1
+
+          sudo rm -f /etc/resolv.conf
+          sudo tee /etc/dnsmasq.conf <<'EOL'
+          server=8.8.8.8
+          server=8.8.4.4
+          srv-host=_minecraft._tcp.xrjr.mcutils,localhost,25565,0,5
+          EOL
+      - run: echo "nameserver 127.0.0.1" | sudo tee /etc/resolv.conf
+      - run: sudo systemctl restart dnsmasq
+      - run: sleep 60
+      - run: ./mcutils ping xrjr.mcutils 25565
   
   vanilla-ping-legacy:
     runs-on: ubuntu-latest
@@ -55,7 +70,7 @@ jobs:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 30
+      - run: sleep 60
       - run: ./mcutils ping-legacy localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -74,7 +89,7 @@ jobs:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 30
+      - run: sleep 60
       - run: ./mcutils ping-legacy-1.6.4 localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -92,7 +107,7 @@ jobs:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 30
+      - run: sleep 60
       - run: ./mcutils ping localhost 25565
       - run: docker stop test-minecraft-server
 
@@ -112,7 +127,7 @@ jobs:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565/udp -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 30
+      - run: sleep 60
       - run: ./mcutils query-basic localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -132,7 +147,7 @@ jobs:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565/udp -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 30
+      - run: sleep 60
       - run: ./mcutils query-full localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -152,7 +167,7 @@ jobs:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25575:25575 -e VERSION=${{ matrix.version }} -e RCON_PASSWORD=password --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 30
+      - run: sleep 60
       - run: ./mcutils rcon localhost 25575 password "say hello"
       - run: docker stop test-minecraft-server
   
@@ -169,6 +184,6 @@ jobs:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=TRUE -e VERSION=${{ matrix.version }} -p 19132:19132/udp itzg/minecraft-bedrock-server
-      - run: sleep 30
+      - run: sleep 60
       - run: ./mcutils ping-bedrock localhost 19132
       - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
         with:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
-      - run:  docker run --rm -it -e EULA=TRUE -e VERSION=${{ matrix.version }} -p 19132:19132/udp itzg/minecraft-bedrock-server
+      - run: docker run --rm -d -e EULA=TRUE -e VERSION=${{ matrix.version }} -p 19132:19132/udp itzg/minecraft-bedrock-server
       - run: sleep 60
       - run: ./mcutils rcon localhost 25575 password "say hello"
       - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
           - 1.5.2
           - 1.6.4
           - 1.7.10
+          - latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -54,4 +55,80 @@ jobs:
       - run: sleep 120
       - run: ./mcutils ping-legacy localhost 25565
       - run: docker stop test-minecraft-server
+  
+  vanilla-ping-legacy-1-6-4:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - 1.6.4
+          - 1.7.10
+          - latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
+      - run: sleep 120
+      - run: ./mcutils ping-legacy-1.6.4 localhost 25565
+      - run: docker stop test-minecraft-server
+  
+  vanilla-ping-slp:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - 1.7.10
+          - latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
+      - run: sleep 120
+      - run: ./mcutils ping localhost 25565
+      - run: docker stop test-minecraft-server
 
+  vanilla-query-basic:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - 1.2.5
+          - 1.6.4
+          - 1.7.10
+          - latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
+      - run: sleep 120
+      - run: ./mcutils query-basic localhost 25565
+      - run: docker stop test-minecraft-server
+  
+  vanilla-query-full:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - 1.2.5
+          - 1.6.4
+          - 1.7.10
+          - latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
+      - run: sleep 120
+      - run: ./mcutils query-full localhost 25565
+      - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
-      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
+      - run: docker run --rm -d -e EULA=true -p 25565:25565/udp -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
       - run: sleep 120
       - run: ./mcutils query-basic localhost 25565
       - run: docker stop test-minecraft-server
@@ -128,7 +128,7 @@ jobs:
         with:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
-      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
+      - run: docker run --rm -d -e EULA=true -p 25565:25565/udp -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
       - run: sleep 120
       - run: ./mcutils query-full localhost 25565
       - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 120
+      - run: sleep 60
       - run: ./mcutils ping-legacy localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -71,7 +71,7 @@ jobs:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 120
+      - run: sleep 60
       - run: ./mcutils ping-legacy-1.6.4 localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -89,7 +89,7 @@ jobs:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 120
+      - run: sleep 60
       - run: ./mcutils ping localhost 25565
       - run: docker stop test-minecraft-server
 
@@ -109,7 +109,7 @@ jobs:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565/udp -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 120
+      - run: sleep 60
       - run: ./mcutils query-basic localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -129,7 +129,7 @@ jobs:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565/udp -e VERSION=${{ matrix.version }} -e ENABLE_QUERY=true --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 120
+      - run: sleep 60
       - run: ./mcutils query-full localhost 25565
       - run: docker stop test-minecraft-server
   
@@ -149,6 +149,23 @@ jobs:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25575:25575 -e VERSION=${{ matrix.version }} -e RCON_PASSWORD=password --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 120
+      - run: sleep 60
+      - run: ./mcutils rcon localhost 25575 password "say hello"
+      - run: docker stop test-minecraft-server
+  
+  vanilla-bedrock-ping:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version:
+          - latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.3
+      - run: go build -ldflags="-w -s" ./cmd/mcutils
+      - run:  docker run --rm -it -e EULA=TRUE -e VERSION=${{ matrix.version }} -p 19132:19132/udp itzg/minecraft-bedrock-server
+      - run: sleep 60
       - run: ./mcutils rcon localhost 25575 password "say hello"
       - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,5 +167,5 @@ jobs:
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=TRUE -e VERSION=${{ matrix.version }} -p 19132:19132/udp itzg/minecraft-bedrock-server
       - run: sleep 60
-      - run: ./mcutils rcon localhost 25575 password "say hello"
+      - run: ./mcutils bedrock-ping localhost 19132
       - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
-      - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} -e RCON_PASSWORD=password --name test-minecraft-server itzg/minecraft-server
+      - run: docker run --rm -d -e EULA=true -p 25575:25575 -e VERSION=${{ matrix.version }} -e RCON_PASSWORD=password --name test-minecraft-server itzg/minecraft-server
       - run: sleep 120
       - run: ./mcutils rcon localhost 25575 password "say hello"
       - run: docker stop test-minecraft-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           go-version: 1.26.3
       - run: go build -ldflags="-w -s" ./cmd/mcutils
       - run: docker run --rm -d -e EULA=true -p 25565:25565 -e VERSION=${{ matrix.version }} --name test-minecraft-server itzg/minecraft-server
-      - run: sleep 10
+      - run: sleep 120
       - run: ./mcutils ping-legacy localhost 25565
       - run: docker stop test-minecraft-server
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,7 +183,7 @@ jobs:
         with:
           go-version: ${{ env.go-version }}
       - run: go build -ldflags="-w -s" ./cmd/mcutils
-      - run: docker run --rm -d -e EULA=TRUE -e VERSION=${{ matrix.version }} -p 19132:19132/udp itzg/minecraft-bedrock-server
+      - run: docker run --rm -d -e EULA=TRUE -e VERSION=${{ matrix.version }} -p 19132:19132/udp --name test-minecraft-server itzg/minecraft-bedrock-server
       - run: sleep 60
       - run: ./mcutils ping-bedrock localhost 19132
       - run: docker stop test-minecraft-server

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ err := pingclient.Connect()
 
 
 // UnconnectedPing is a request that retrieve server informations and latency
-pong, latency, err := pingclient.UnconnctedPing()
+pong, latency, err := pingclient.UnconnectedPing()
 
 // Disconnect closes the connection
 err = pingclient.Disconnect()

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This project also contains an helper in communication with tcp/udp, called `pkg/
 
 
 
-> All relevant protocols implementations support SRV record resolving.
+> All protocols implementations support SRV record resolving.
 >
 > Rcon implementation supports fragmented response packets.
 >
@@ -243,4 +243,16 @@ client.SkipSRVLookup = true
 client.DialTimeout = 10 * time.Second
 client.ReadTimeout = 500 * time.Milisecond
 ```
+</details>
+
+<details>
+<summary>Note on SRV resolving</summary>
+
+All clients are created with a default option that performs SRV resolving, besides bedrock one. This is because there is no such SRV records mechanism on bedrock servers.
+
+As we've seen in the client customization part, you can disbale SRV resolving for clients that perform it by default, and you can even enable it for bedrock one. In this last case, it would be using the same service and protocol as the java edition, but please note that it is not standard.
+
+For clients that rely on UDP streams (currently query and bedrock), you can also change the protocol for the SRV lookup (default is `_minecraft._tcp`, you can make it `_minecraft._udp`). See `ForceUDPProtocolForSRVLookup` option. Please note that, again, this is not standard at all.
+
+SRV resolution is automatically skipped at client creation if the provided hostname either is `localhost` or a textual IP. While this is how most minecraft client works for optimization purposes, you can still re-enable it right after client creation.
 </details>

--- a/README.md
+++ b/README.md
@@ -10,17 +10,15 @@
 
 ## Informations
 
-![test workflow](https://github.com/xrjr/mcutils/actions/workflows/tests.yml/badge.svg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/xrjr/mcutils.svg)](https://pkg.go.dev/github.com/xrjr/mcutils) ![test workflow](https://github.com/xrjr/mcutils/actions/workflows/tests.yml/badge.svg)
 
 ### General
 
-All protocols are implemented in Go, without any external dependency. All protocols should be supported on any platform/architecture as long as Go can compile them.
+All protocols are implemented in pure Go, without any external dependency besides stdlib. All protocols should be supported on any platform/architecture as long as Go can compile them.
 
 All protocols have been implemented using [minecraft.wiki](https://minecraft.wiki). All of them are 100% compliant with the standard described there.
 
 This project also contains an helper in communication with tcp/udp, called `pkg/networking`.
-
-This project has no dependency.
 
 ### Supported protocols
 
@@ -34,7 +32,7 @@ This project has no dependency.
 
 
 
-> All protocols implementations support SRV record resolving. 
+> All relevant protocols implementations support SRV record resolving.
 >
 > Rcon implementation supports fragmented response packets.
 >
@@ -232,5 +230,17 @@ pong, latency, err := pingclient.UnconnectedPing()
 
 // Disconnect closes the connection
 err = pingclient.Disconnect()
+```
+</details>
+
+<details>
+<summary>Customize client parameters</summary>
+
+Each protocol client is created with reasonable defaults, but you may need to adapt them to your very own requirements. For example, you may want to customize timeouts or skip the SRV lookup. Explore exported fields of clients to see more.
+
+```go
+client.SkipSRVLookup = true
+client.DialTimeout = 10 * time.Second
+client.ReadTimeout = 500 * time.Milisecond
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -254,5 +254,5 @@ As we've seen in the client customization part, you can disbale SRV resolving fo
 
 For clients that rely on UDP streams (currently query and bedrock), you can also change the protocol for the SRV lookup (default is `_minecraft._tcp`, you can make it `_minecraft._udp`). See `ForceUDPProtocolForSRVLookup` option. Please note that, again, this is not standard at all.
 
-SRV resolution is automatically skipped at client creation if the provided hostname either is `localhost` or a textual IP. While this is how most minecraft client works for optimization purposes, you can still re-enable it right after client creation.
+SRV resolution is automatically skipped at client creation if the provided hostname either is `localhost` or a textual IP. While this is how most minecraft client work for optimization purposes, you can still re-enable it right after client creation.
 </details>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 All protocols are implemented in Go, without any external dependency. All protocols should be supported on any platform/architecture as long as Go can compile them.
 
-All protocols have been implemented using [wiki.vg](https://wiki.vg/). All of them are 100% compliant with the standard described there.
+All protocols have been implemented using [minecraft.wiki](https://minecraft.wiki). All of them are 100% compliant with the standard described there.
 
 This project also contains an helper in communication with tcp/udp, called `pkg/networking`.
 
@@ -24,13 +24,13 @@ This project has no dependency.
 
 ### Supported protocols
 
-- [Ping](https://wiki.vg/Server_List_Ping) (Server List Ping)
+- [Ping](https://minecraft.wiki/w/Java_Edition_protocol/Server_List_Ping) (Server List Ping)
 
-- [Query](https://wiki.vg/Query)
+- [Query](https://minecraft.wiki/w/Query)
 
-- [Rcon](https://wiki.vg/Rcon)
+- [Rcon](https://minecraft.wiki/w/RCON)
 
-- [Bedrock Ping](https://wiki.vg/Raknet_Protocol)
+- [Bedrock Ping](https://minecraft.wiki/w/RakNet)
 
 
 

--- a/pkg/bedrock/bedrock.go
+++ b/pkg/bedrock/bedrock.go
@@ -1,5 +1,5 @@
 // bedrock package implements the unconnected ping sequence of the raknet protocol (used by minecraft bedrock servers).
-// This package is strictly compliant with the following documentation : https://wiki.vg/Raknet_Protocol.
+// This package is strictly compliant with the following documentation : https://minecraft.wiki/w/RakNet.
 package bedrock
 
 // Ping returns the server infos, and latency of a minecraft bedrock server.

--- a/pkg/bedrock/client.go
+++ b/pkg/bedrock/client.go
@@ -161,20 +161,25 @@ type PingClient struct {
 	ClientGUID uint64
 
 	// options
-	DialTimeout time.Duration
-	ReadTimeout time.Duration
+	SkipSRVLookup                bool
+	ForceUDPProtocolForSRVLookup bool
+	DialTimeout                  time.Duration
+	ReadTimeout                  time.Duration
 }
 
 // NewClient returns a well-formed *PingClient.
 // ClientGUID is set to a random value.
+// Unlike other clients, bedrock-ping one is created with a SkipSRVLookup option set to true, as there is normally no such mechanism on bedrock servers.
 func NewClient(hostname string, port int) *PingClient {
 	return &PingClient{
 		hostname:   hostname,
 		port:       port,
 		ClientGUID: uint64(rand.Int()),
 
-		DialTimeout: 5 * time.Second,
-		ReadTimeout: 5 * time.Second,
+		SkipSRVLookup:                true,
+		ForceUDPProtocolForSRVLookup: false,
+		DialTimeout:                  5 * time.Second,
+		ReadTimeout:                  5 * time.Second,
 	}
 }
 
@@ -185,8 +190,9 @@ func (client *PingClient) Connect() error {
 	}
 
 	conn, err := networking.DialUDP(client.hostname, client.port, networking.DialUDPOptions{
-		SkipSRVLookup: true, // there is no SRV lookup mechanism for bedrock servers
-		DialTimeout:   client.DialTimeout,
+		SkipSRVLookup:                client.SkipSRVLookup,
+		ForceUDPProtocolForSRVLookup: client.ForceUDPProtocolForSRVLookup,
+		DialTimeout:                  client.DialTimeout,
 	})
 	if err != nil {
 		return err

--- a/pkg/bedrock/client.go
+++ b/pkg/bedrock/client.go
@@ -161,10 +161,8 @@ type PingClient struct {
 	ClientGUID uint64
 
 	// options
-	SkipSRVLookup                bool
-	ForceUDPProtocolForSRVLookup bool
-	DialTimeout                  time.Duration
-	ReadTimeout                  time.Duration
+	DialTimeout time.Duration
+	ReadTimeout time.Duration
 }
 
 // NewClient returns a well-formed *PingClient.
@@ -175,10 +173,8 @@ func NewClient(hostname string, port int) *PingClient {
 		port:       port,
 		ClientGUID: uint64(rand.Int()),
 
-		SkipSRVLookup:                false,
-		ForceUDPProtocolForSRVLookup: false,
-		DialTimeout:                  5 * time.Second,
-		ReadTimeout:                  5 * time.Second,
+		DialTimeout: 5 * time.Second,
+		ReadTimeout: 5 * time.Second,
 	}
 }
 
@@ -189,9 +185,8 @@ func (client *PingClient) Connect() error {
 	}
 
 	conn, err := networking.DialUDP(client.hostname, client.port, networking.DialUDPOptions{
-		SkipSRVLookup:                client.SkipSRVLookup,
-		ForceUDPProtocolForSRVLookup: client.ForceUDPProtocolForSRVLookup,
-		DialTimeout:                  client.DialTimeout,
+		SkipSRVLookup: true, // there is no SRV lookup mechanism for bedrock servers
+		DialTimeout:   client.DialTimeout,
 	})
 	if err != nil {
 		return err

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -107,14 +107,14 @@ type DialUDPOptions struct {
 func DialUDP(hostname string, port int, options DialUDPOptions) (*UDPConn, error) {
 	var _hostname string = hostname
 	var _port int = port
-	var SRVLookupProtocol string = "tcp"
+	var protocol string = "tcp"
 
 	if options.ForceUDPProtocolForSRVLookup {
-		SRVLookupProtocol = "udp"
+		protocol = "udp"
 	}
 
 	if !options.SkipSRVLookup {
-		_, addrs, err := net.LookupSRV("minecraft", SRVLookupProtocol, hostname)
+		_, addrs, err := net.LookupSRV("minecraft", protocol, hostname)
 		if err == nil && len(addrs) > 0 {
 			_hostname = addrs[0].Target
 			_port = int(addrs[0].Port)

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -42,7 +42,11 @@ func DialTCP(hostname string, port int, options DialTCPOptions) (*TCPConn, error
 	var _hostname string = hostname
 	var _port int = port
 
-	if !options.SkipSRVLookup {
+	// skip SRV lookup if one of the following is true:
+	// - option is true
+	// - hostname is localhost
+	// - hostname is a textual IP address
+	if !options.SkipSRVLookup && hostname != "localhost" && net.ParseIP(hostname) != nil {
 		_, addrs, err := net.LookupSRV("minecraft", "tcp", hostname)
 		if err == nil && len(addrs) > 0 {
 			_hostname = addrs[0].Target
@@ -113,7 +117,11 @@ func DialUDP(hostname string, port int, options DialUDPOptions) (*UDPConn, error
 		SRVLookupProtocol = "udp"
 	}
 
-	if !options.SkipSRVLookup {
+	// skip SRV lookup if one of the following is true :
+	// - option is true
+	// - hostname is localhost
+	// - hostname is a textual IP address
+	if !options.SkipSRVLookup && hostname != "localhost" && net.ParseIP(hostname) != nil {
 		_, addrs, err := net.LookupSRV("minecraft", SRVLookupProtocol, hostname)
 		if err == nil && len(addrs) > 0 {
 			_hostname = addrs[0].Target

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -42,11 +42,7 @@ func DialTCP(hostname string, port int, options DialTCPOptions) (*TCPConn, error
 	var _hostname string = hostname
 	var _port int = port
 
-	// skip SRV lookup if one of the following is true:
-	// - option is true
-	// - hostname is localhost
-	// - hostname is a textual IP address
-	if !options.SkipSRVLookup && hostname != "localhost" && net.ParseIP(hostname) == nil {
+	if !options.SkipSRVLookup {
 		_, addrs, err := net.LookupSRV("minecraft", "tcp", hostname)
 		if err == nil && len(addrs) > 0 {
 			_hostname = addrs[0].Target
@@ -107,7 +103,7 @@ type DialUDPOptions struct {
 	DialTimeout                  time.Duration
 }
 
-// DialTCP resolve UDP address and connects to the address using UDP.
+// DialUDP resolve UDP address and connects to the address using UDP.
 func DialUDP(hostname string, port int, options DialUDPOptions) (*UDPConn, error) {
 	var _hostname string = hostname
 	var _port int = port
@@ -117,11 +113,7 @@ func DialUDP(hostname string, port int, options DialUDPOptions) (*UDPConn, error
 		SRVLookupProtocol = "udp"
 	}
 
-	// skip SRV lookup if one of the following is true :
-	// - option is true
-	// - hostname is localhost
-	// - hostname is a textual IP address
-	if !options.SkipSRVLookup && hostname != "localhost" && net.ParseIP(hostname) == nil {
+	if !options.SkipSRVLookup {
 		_, addrs, err := net.LookupSRV("minecraft", SRVLookupProtocol, hostname)
 		if err == nil && len(addrs) > 0 {
 			_hostname = addrs[0].Target

--- a/pkg/networking/networking.go
+++ b/pkg/networking/networking.go
@@ -46,7 +46,7 @@ func DialTCP(hostname string, port int, options DialTCPOptions) (*TCPConn, error
 	// - option is true
 	// - hostname is localhost
 	// - hostname is a textual IP address
-	if !options.SkipSRVLookup && hostname != "localhost" && net.ParseIP(hostname) != nil {
+	if !options.SkipSRVLookup && hostname != "localhost" && net.ParseIP(hostname) == nil {
 		_, addrs, err := net.LookupSRV("minecraft", "tcp", hostname)
 		if err == nil && len(addrs) > 0 {
 			_hostname = addrs[0].Target
@@ -121,7 +121,7 @@ func DialUDP(hostname string, port int, options DialUDPOptions) (*UDPConn, error
 	// - option is true
 	// - hostname is localhost
 	// - hostname is a textual IP address
-	if !options.SkipSRVLookup && hostname != "localhost" && net.ParseIP(hostname) != nil {
+	if !options.SkipSRVLookup && hostname != "localhost" && net.ParseIP(hostname) == nil {
 		_, addrs, err := net.LookupSRV("minecraft", SRVLookupProtocol, hostname)
 		if err == nil && len(addrs) > 0 {
 			_hostname = addrs[0].Target

--- a/pkg/ping/client.go
+++ b/pkg/ping/client.go
@@ -139,7 +139,7 @@ type PingClient struct {
 func NewClient(hostname string, port int) *PingClient {
 	var skipSRVLookup = false
 
-	if hostname == "localhost" && net.ParseIP(hostname) != nil {
+	if hostname == "localhost" || net.ParseIP(hostname) != nil {
 		skipSRVLookup = true
 	}
 

--- a/pkg/ping/client.go
+++ b/pkg/ping/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"net"
 	"time"
 
 	"github.com/xrjr/mcutils/pkg/networking"
@@ -136,11 +137,17 @@ type PingClient struct {
 
 // NewClient returns a well-formed *PingClient.
 func NewClient(hostname string, port int) *PingClient {
+	var skipSRVLookup = false
+
+	if hostname == "localhost" && net.ParseIP(hostname) != nil {
+		skipSRVLookup = true
+	}
+
 	return &PingClient{
 		hostname: hostname,
 		port:     port,
 
-		SkipSRVLookup: false,
+		SkipSRVLookup: skipSRVLookup,
 		DialTimeout:   5 * time.Second,
 		ReadTimeout:   5 * time.Second,
 	}

--- a/pkg/ping/infos.go
+++ b/pkg/ping/infos.go
@@ -21,10 +21,11 @@ type infosPlayers struct {
 
 // Infos represents usual informations contained in ping response.
 type Infos struct {
-	Version     infosVersion `json:"version"`
-	Players     infosPlayers `json:"players"`
-	Description string       `json:"description"`
-	Favicon     string       `json:"favicon"`
+	Version            infosVersion `json:"version"`
+	Players            infosPlayers `json:"players"`
+	Description        string       `json:"description"`
+	Favicon            string       `json:"favicon"`
+	EnforcesSecureChat bool         `json:"enforcesSecureChat"`
 }
 
 // Infos extracts informations from ping response properties (JSON), and put it into an Infos structure.
@@ -130,6 +131,14 @@ func (m *JSON) Infos() Infos {
 		faviconString, ok := favicon.(string)
 		if ok {
 			infos.Favicon = faviconString
+		}
+	}
+
+	enforcesSecureChat, ok := (*m)["enforcesSecureChat"]
+	if ok {
+		enforcesSecureChatBool, ok := enforcesSecureChat.(bool)
+		if ok {
+			infos.EnforcesSecureChat = enforcesSecureChatBool
 		}
 	}
 

--- a/pkg/ping/legacy.go
+++ b/pkg/ping/legacy.go
@@ -214,12 +214,13 @@ func (client *PingClientLegacy) Connect() error {
 
 // Ping sends a legacy ping request to the server, and returns various informations about the server, and the latency in ms.
 // If the minecraft server has a version <= 1.3, ProtocolNumber and MinecraftVersion are not set.
+// Note that legacy ping should be working on most servers that don't require host to be set, but it is notoriously slow on 1.6.x vanilla servers.
 func (client *PingClientLegacy) Ping() (LegacyPingInfos, int, error) {
 	return client.ping(false)
 }
 
 // Ping1_6_4 sends a legacy ping request to the server (using 1.6+ SLP protocol), and returns various informations about the server, and the latency in ms.
-// If the minecraft server has a version <= 1.3, ProtocolNumber and MinecraftVersion are not set.
+// Note that on vanilla servers < 1.4.x, this protocol usually don't work.
 func (client *PingClientLegacy) Ping1_6_4() (LegacyPingInfos, int, error) {
 	return client.ping(true)
 }

--- a/pkg/ping/legacy.go
+++ b/pkg/ping/legacy.go
@@ -187,7 +187,7 @@ type PingClientLegacy struct {
 func NewClientLegacy(hostname string, port int) *PingClientLegacy {
 	var skipSRVLookup = false
 
-	if hostname == "localhost" && net.ParseIP(hostname) != nil {
+	if hostname == "localhost" || net.ParseIP(hostname) != nil {
 		skipSRVLookup = true
 	}
 

--- a/pkg/ping/legacy.go
+++ b/pkg/ping/legacy.go
@@ -3,6 +3,7 @@ package ping
 import (
 	"bytes"
 	"encoding/binary"
+	"net"
 	"strconv"
 	"time"
 	"unicode/utf16"
@@ -184,11 +185,17 @@ type PingClientLegacy struct {
 
 // NewClientLegacy returns a well-formed *LegacyPingClient.
 func NewClientLegacy(hostname string, port int) *PingClientLegacy {
+	var skipSRVLookup = false
+
+	if hostname == "localhost" && net.ParseIP(hostname) != nil {
+		skipSRVLookup = true
+	}
+
 	return &PingClientLegacy{
 		hostname: hostname,
 		port:     port,
 
-		SkipSRVLookup: false,
+		SkipSRVLookup: skipSRVLookup,
 		DialTimeout:   5 * time.Second,
 		ReadTimeout:   5 * time.Second,
 	}

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -41,6 +41,7 @@ func Ping(hostname string, port int) (JSON, int, error) {
 // PingLegacy returns the legacy server list ping infos, and latency of a minecraft server.
 // If an error occurred at any point of the process, an empty response, a latency of -1, and a non nil error are returned.
 // If the minecraft server has a version <= 1.3, ProtocolNumber and MinecraftVersion are not set.
+// Note that legacy ping should be working on most servers that don't require host to be set, but it is notoriously slow on 1.6.x vanilla servers.
 func PingLegacy(hostname string, port int) (LegacyPingInfos, int, error) {
 	client := NewClientLegacy(hostname, port)
 
@@ -64,7 +65,7 @@ func PingLegacy(hostname string, port int) (LegacyPingInfos, int, error) {
 
 // PingLegacy1_6_4 returns the legacy server list ping infos (using 1.6+ SLP protocol), and latency of a minecraft server.
 // If an error occurred at any point of the process, an empty response, a latency of -1, and a non nil error are returned.
-// If the minecraft server has a version <= 1.3, ProtocolNumber and MinecraftVersion are not set.
+// Note that on vanilla servers < 1.4.x, this protocol usually don't work.
 func PingLegacy1_6_4(hostname string, port int) (LegacyPingInfos, int, error) {
 	client := NewClientLegacy(hostname, port)
 

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -1,5 +1,5 @@
 // ping package implements the mincraft Server List Ping protocol.
-// This package is strictly compliant with the following documentation : https://wiki.vg/Server_List_Ping.
+// This package is strictly compliant with the following documentation : https://minecraft.wiki/w/Java_Edition_protocol/Server_List_Ping.
 package ping
 
 import "errors"

--- a/pkg/query/client.go
+++ b/pkg/query/client.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"math/rand"
+	"net"
 	"strconv"
 	"time"
 
@@ -248,11 +249,17 @@ type QueryClient struct {
 
 // NewClient returns a well-formed *QueryClient.
 func NewClient(hostname string, port int) *QueryClient {
+	var skipSRVLookup = false
+
+	if hostname == "localhost" && net.ParseIP(hostname) != nil {
+		skipSRVLookup = true
+	}
+
 	return &QueryClient{
 		hostname: hostname,
 		port:     port,
 
-		SkipSRVLookup:                false,
+		SkipSRVLookup:                skipSRVLookup,
 		ForceUDPProtocolForSRVLookup: false,
 		DialTimeout:                  5 * time.Second,
 		ReadTimeout:                  5 * time.Second,

--- a/pkg/query/client.go
+++ b/pkg/query/client.go
@@ -251,7 +251,7 @@ type QueryClient struct {
 func NewClient(hostname string, port int) *QueryClient {
 	var skipSRVLookup = false
 
-	if hostname == "localhost" && net.ParseIP(hostname) != nil {
+	if hostname == "localhost" || net.ParseIP(hostname) != nil {
 		skipSRVLookup = true
 	}
 

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -1,5 +1,5 @@
 // query package implements the mincraft query protocol.
-// This package is strictly compliant with the following documentation : https://wiki.vg/Query.
+// This package is strictly compliant with the following documentation : https://minecraft.wiki/w/Query.
 package query
 
 // QueryBasic returns the basic stat of a minecraft server.

--- a/pkg/rcon/client.go
+++ b/pkg/rcon/client.go
@@ -178,7 +178,7 @@ type RCONClient struct {
 func NewClient(hostname string, port int) *RCONClient {
 	var skipSRVLookup = false
 
-	if hostname == "localhost" && net.ParseIP(hostname) != nil {
+	if hostname == "localhost" || net.ParseIP(hostname) != nil {
 		skipSRVLookup = true
 	}
 

--- a/pkg/rcon/client.go
+++ b/pkg/rcon/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"time"
 
 	"github.com/xrjr/mcutils/pkg/networking"
@@ -175,12 +176,18 @@ type RCONClient struct {
 
 // NewClient returns a well-formed *RCONClient.
 func NewClient(hostname string, port int) *RCONClient {
+	var skipSRVLookup = false
+
+	if hostname == "localhost" && net.ParseIP(hostname) != nil {
+		skipSRVLookup = true
+	}
+
 	return &RCONClient{
 		hostname:      hostname,
 		port:          port,
 		authenticated: false,
 
-		SkipSRVLookup: false,
+		SkipSRVLookup: skipSRVLookup,
 		DialTimeout:   5 * time.Second,
 		ReadTimeout:   5 * time.Second,
 	}

--- a/pkg/rcon/rcon.go
+++ b/pkg/rcon/rcon.go
@@ -1,5 +1,5 @@
 // rcon package implements the minecraft rcon protocol (based on the source rcon protocol).
-// This package is strictly compliant with the following documentation : https://wiki.vg/RCON.
+// This package is strictly compliant with the following documentation : https://minecraft.wiki/w/RCON.
 package rcon
 
 import "errors"

--- a/pkg/rcon/rcon.go
+++ b/pkg/rcon/rcon.go
@@ -32,7 +32,7 @@ func Rcon(hostname string, port int, password string, command string) (string, e
 		return "", nil
 	}
 
-	client.Disconnect()
+	err = client.Disconnect()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR has several different goals :
- [doc] Update documentation URLs as `wiki.vg` is no longer up and replaced with `minecraft.wiki`
- [doc] Fix typos
- [doc] Improve README as it is the main source of documentation
- [bug] Fix error check on RCON disconnect
- [feature] Add support for `enforcesSecureChat` parsing in SLP
- [optimization] Automatically set skip SRV lookup on client creation if hostname is IP or localhost (see itzg/mc-monitor#140). If needed, the option can still be manually set afterward. This should not change behavior except preventing unnecessary DNS lookup requests
- [optimization] SkipSRVLookup now is disabled by default for bedrock client as it is not a standard mechanism. It can still be re-enabled afterwards. No API change, and again it should not impact anyone as this behavior was non standard either way
- [tests] Add a bunch of new tests :
  - CLI build and version command test
  - SRV lookup test using custom local dns config
  - all protocols tests using temporary servers and commands performed via CLI (tests are considered passing if the CLI exits with zero)

This PR was expected to be pretty small but ended up being pretty big with new docs, behavior changes (DNS) and of course a huge improvement on testing. Small DNS changes *may* have an impact on you if you were using non standard mechanism, but every new optimization introduced as a way to mitigate it (except  for CLI).