### PR TITLE
Fix the incorrect use of zigzag in the compute of signed varint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All protocols are implemented in pure Go, without any external dependency beside
 
 All protocols have been implemented using [minecraft.wiki](https://minecraft.wiki). All of them are 100% compliant with the standard described there.
 
-This project also contains an helper in communication with tcp/udp, called `pkg/networking`.
+This project also contains an helper in communication with tcp/udp, called `pkg/networking`. While it is published as a package, it is primarly used in this library and its API should not be considered stable.
 
 ### Supported protocols
 

--- a/pkg/networking/input.go
+++ b/pkg/networking/input.go
@@ -116,14 +116,14 @@ func (in *Input) ReadUVarInt() (uint64, error) {
 	return uvarint, nil
 }
 
-// ReadVarInt64 tries to read a signed varint from the input.
+// ReadVarInt64 tries to read a signed varint from the input (non zigzag).
 func (in *Input) ReadVarInt() (int64, error) {
-	varint, err := binary.ReadVarint(in)
+	uvarint, err := binary.ReadUvarint(in)
 	if err != nil {
 		return 0, err
 	}
 
-	return varint, nil
+	return int64(uvarint), nil
 }
 
 // ReadNullTerminatedString tries to read a null terminated string from the input.

--- a/pkg/networking/input.go
+++ b/pkg/networking/input.go
@@ -3,7 +3,13 @@ package networking
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
+)
+
+var (
+	ErrVarIntTooBig  error = errors.New("VarInt is too big")
+	ErrVarLongTooBig error = errors.New("VarLong is too big")
 )
 
 // Input represents a connection input (i.e. what's read from the connection). It wraps several helpers to read from this input.
@@ -106,24 +112,36 @@ func (in *Input) ReadLittleEndianInt64() (uint64, error) {
 	return binary.LittleEndian.Uint64(buf[0:8]), nil
 }
 
-// ReadUVarInt64 tries to read an unsigned varint from the input.
-func (in *Input) ReadUVarInt() (uint64, error) {
-	uvarint, err := binary.ReadUvarint(in)
-	if err != nil {
-		return 0, err
+// ReadVarInt tries to read a varint from the input.
+func (in *Input) ReadVarInt() (int32, error) {
+	var result uint32
+	for i := 0; i < 5; i++ {
+		b, err := in.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		result |= uint32(b&SEGMENT_BITS) << (7 * i)
+		if b&CONTINUE_BIT == 0 {
+			return int32(result), nil
+		}
 	}
-
-	return uvarint, nil
+	return 0, ErrVarIntTooBig
 }
 
-// ReadVarInt64 tries to read a signed varint from the input (non zigzag).
-func (in *Input) ReadVarInt() (int64, error) {
-	uvarint, err := binary.ReadUvarint(in)
-	if err != nil {
-		return 0, err
+// ReadVarInt tries to read a varlong from the input.
+func (in *Input) ReadVarLong() (int64, error) {
+	var result uint64
+	for i := 0; i < 10; i++ {
+		b, err := in.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		result |= uint64(b&SEGMENT_BITS) << (7 * i)
+		if b&CONTINUE_BIT == 0 {
+			return int64(result), nil
+		}
 	}
-
-	return int64(uvarint), nil
+	return 0, ErrVarLongTooBig
 }
 
 // ReadNullTerminatedString tries to read a null terminated string from the input.
@@ -149,7 +167,7 @@ func (in *Input) ReadNullTerminatedString() (string, error) {
 // ReadString tries to read a standard minecraft protocol string from the input.
 // It is a UTF-8 string prefixed with its size in bytes as an unsigned varint.
 func (in *Input) ReadString() (string, error) {
-	length, err := in.ReadUVarInt()
+	length, err := in.ReadVarInt()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/networking/input.go
+++ b/pkg/networking/input.go
@@ -120,8 +120,8 @@ func (in *Input) ReadVarInt() (int32, error) {
 		if err != nil {
 			return 0, err
 		}
-		result |= uint32(b&SEGMENT_BITS) << (7 * i)
-		if b&CONTINUE_BIT == 0 {
+		result |= uint32(b&VARINT_SEGMENT_BITS) << (7 * i)
+		if b&VARINT_CONTINUE_BIT == 0 {
 			return int32(result), nil
 		}
 	}
@@ -136,8 +136,8 @@ func (in *Input) ReadVarLong() (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		result |= uint64(b&SEGMENT_BITS) << (7 * i)
-		if b&CONTINUE_BIT == 0 {
+		result |= uint64(b&VARINT_SEGMENT_BITS) << (7 * i)
+		if b&VARINT_CONTINUE_BIT == 0 {
 			return int64(result), nil
 		}
 	}

--- a/pkg/networking/input_test.go
+++ b/pkg/networking/input_test.go
@@ -236,11 +236,15 @@ func TestReadUVarInt(t *testing.T) {
 func TestReadVarInt(t *testing.T) {
 	inputs := []Input{
 		NewInput(bytes.NewBuffer([]byte{232, 201, 171, 166, 15})),
+		NewInput(bytes.NewBuffer([]byte{140, 155, 234, 172, 248, 255, 255, 255, 255, 1})),
 		NewInput(bytes.NewBuffer([]byte{231, 201, 171, 166, 15})),
 		NewInput(bytes.NewBuffer([]byte{231, 201, 171, 166})),
+		NewInput(bytes.NewBuffer([]byte{0})),
+		NewInput(bytes.NewBuffer([]byte{1})),
+		NewInput(bytes.NewBuffer([]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 1})),
 	}
-	expectedValues := []int64{2053468788, -2053468788, 0}
-	expectedErrors := []bool{false, false, true}
+	expectedValues := []int64{4106937576, -2053468788, 4106937575, 0, 0, 1, -1}
+	expectedErrors := []bool{false, false, false, true, false, false, false}
 
 	var res int64
 	var err error

--- a/pkg/networking/input_test.go
+++ b/pkg/networking/input_test.go
@@ -209,20 +209,52 @@ func TestReadLittleEndianInt64(t *testing.T) {
 	}
 }
 
-func TestReadUVarInt(t *testing.T) {
+func TestReadVarInt(t *testing.T) {
 	inputs := []Input{
-		NewInput(bytes.NewBuffer([]byte{232, 201, 171, 166, 15})),
-		NewInput(bytes.NewBuffer([]byte{231, 201, 171, 166, 15})),
-		NewInput(bytes.NewBuffer([]byte{231, 201, 171, 166})),
+		NewInput(bytes.NewBuffer([]byte{0})),
+		NewInput(bytes.NewBuffer([]byte{1})),
+		NewInput(bytes.NewBuffer([]byte{2})),
+		NewInput(bytes.NewBuffer([]byte{127})),
+		NewInput(bytes.NewBuffer([]byte{128, 1})),
+		NewInput(bytes.NewBuffer([]byte{255, 1})),
+		NewInput(bytes.NewBuffer([]byte{221, 199, 1})),
+		NewInput(bytes.NewBuffer([]byte{255, 255, 127})),
+		NewInput(bytes.NewBuffer([]byte{255, 255, 255, 255, 7})),
+		NewInput(bytes.NewBuffer([]byte{255, 255, 255, 255, 15})),
+		NewInput(bytes.NewBuffer([]byte{128, 128, 128, 128, 8})),
 	}
-	expectedValues := []uint64{4106937576, 4106937575, 0}
-	expectedErrors := []bool{false, false, true}
+	expectedValues := []int32{
+		0,
+		1,
+		2,
+		127,
+		128,
+		255,
+		25565,
+		2097151,
+		2147483647,
+		-1,
+		-2147483648,
+	}
+	expectedErrors := []bool{
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+	}
 
-	var res uint64
+	var res int32
 	var err error
 
 	for i := 0; i < len(inputs); i++ {
-		res, err = inputs[i].ReadUVarInt()
+		res, err = inputs[i].ReadVarInt()
 
 		if res != expectedValues[i] {
 			t.Errorf("Value %d: Expected %v got %v.", i, expectedValues[i], res)
@@ -233,24 +265,52 @@ func TestReadUVarInt(t *testing.T) {
 	}
 }
 
-func TestReadVarInt(t *testing.T) {
+func TestReadVarLong(t *testing.T) {
 	inputs := []Input{
-		NewInput(bytes.NewBuffer([]byte{232, 201, 171, 166, 15})),
-		NewInput(bytes.NewBuffer([]byte{140, 155, 234, 172, 248, 255, 255, 255, 255, 1})),
-		NewInput(bytes.NewBuffer([]byte{231, 201, 171, 166, 15})),
-		NewInput(bytes.NewBuffer([]byte{231, 201, 171, 166})),
 		NewInput(bytes.NewBuffer([]byte{0})),
 		NewInput(bytes.NewBuffer([]byte{1})),
+		NewInput(bytes.NewBuffer([]byte{2})),
+		NewInput(bytes.NewBuffer([]byte{127})),
+		NewInput(bytes.NewBuffer([]byte{128, 1})),
+		NewInput(bytes.NewBuffer([]byte{255, 1})),
+		NewInput(bytes.NewBuffer([]byte{255, 255, 255, 255, 7})),
+		NewInput(bytes.NewBuffer([]byte{255, 255, 255, 255, 255, 255, 255, 255, 127})),
 		NewInput(bytes.NewBuffer([]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 1})),
+		NewInput(bytes.NewBuffer([]byte{128, 128, 128, 128, 248, 255, 255, 255, 255, 1})),
+		NewInput(bytes.NewBuffer([]byte{128, 128, 128, 128, 128, 128, 128, 128, 128, 1})),
 	}
-	expectedValues := []int64{4106937576, -2053468788, 4106937575, 0, 0, 1, -1}
-	expectedErrors := []bool{false, false, false, true, false, false, false}
+	expectedValues := []int64{
+		0,
+		1,
+		2,
+		127,
+		128,
+		255,
+		2147483647,
+		9223372036854775807,
+		-1,
+		-2147483648,
+		-9223372036854775808,
+	}
+	expectedErrors := []bool{
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+		false,
+	}
 
 	var res int64
 	var err error
 
 	for i := 0; i < len(inputs); i++ {
-		res, err = inputs[i].ReadVarInt()
+		res, err = inputs[i].ReadVarLong()
 
 		if res != expectedValues[i] {
 			t.Errorf("Value %d: Expected %v got %v.", i, expectedValues[i], res)

--- a/pkg/networking/output.go
+++ b/pkg/networking/output.go
@@ -3,8 +3,8 @@ package networking
 import "encoding/binary"
 
 const (
-	SEGMENT_BITS byte = 0x7F
-	CONTINUE_BIT byte = 0x80
+	VARINT_SEGMENT_BITS byte = 0x7F
+	VARINT_CONTINUE_BIT byte = 0x80
 )
 
 // Output represents a connection output (i.e. what's written to the connection). It wraps several helpers to write to this output.
@@ -92,10 +92,10 @@ func (out *Output) WriteLittleEndianInt64(i uint64) {
 func (out *Output) WriteVarInt(i int32) {
 	v := uint32(i)
 	for c := 0; c < 5; c++ {
-		currentByte := byte(v & uint32(SEGMENT_BITS))
+		currentByte := byte(v & uint32(VARINT_SEGMENT_BITS))
 		v >>= 7
 		if v != 0 {
-			currentByte |= CONTINUE_BIT
+			currentByte |= VARINT_CONTINUE_BIT
 		}
 		out.WriteByte(currentByte)
 
@@ -109,10 +109,10 @@ func (out *Output) WriteVarInt(i int32) {
 func (out *Output) WriteVarLong(i int64) {
 	v := uint64(i)
 	for c := 0; c < 10; c++ {
-		currentByte := byte(v & uint64(SEGMENT_BITS))
+		currentByte := byte(v & uint64(VARINT_SEGMENT_BITS))
 		v >>= 7
 		if v != 0 {
-			currentByte |= CONTINUE_BIT
+			currentByte |= VARINT_CONTINUE_BIT
 		}
 		out.WriteByte(currentByte)
 		if v == 0 {

--- a/pkg/networking/output.go
+++ b/pkg/networking/output.go
@@ -84,17 +84,43 @@ func (out *Output) WriteLittleEndianInt64(i uint64) {
 }
 
 // WriteUVarInt64 writes an unsigned varint to the output.
-func (out *Output) WriteUVarInt(i uint64) {
+func (out *Output) WriteUVarInt64(i uint64) {
 	uvarintBuf := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutUvarint(uvarintBuf, uint64(i))
 	out.WriteBytes(uvarintBuf[:n])
 }
 
 // WriteVarInt64 writes a signed varint to the output (non zigzag).
-func (out *Output) WriteVarInt(i int64) {
+func (out *Output) WriteVarInt64(i int64) {
 	varintBuf := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutUvarint(varintBuf, uint64(i))
 	out.WriteBytes(varintBuf[:n])
+}
+
+// WriteUVarInt32 writes an unsigned varint to the output.
+func (out *Output) WriteUVarInt32(i uint32) {
+	uvarintBuf := make([]byte, binary.MaxVarintLen32)
+	n := binary.PutUvarint(uvarintBuf, uint64(i))
+	out.WriteBytes(uvarintBuf[:n])
+}
+
+// WriteVarInt32 writes a signed varint to the output (non zigzag).
+func (out *Output) WriteVarInt32(i int32) {
+	varintBuf := make([]byte, binary.MaxVarintLen32)
+	n := binary.PutUvarint(varintBuf, uint64(i))
+	out.WriteBytes(varintBuf[:n])
+}
+
+// WriteUVarInt writes an unsigned varint32 to the output.
+// uint64 will be casted to uint32, as it is minecraft largest type length.
+func (out *Output) WriteUVarInt(i uint64) {
+	out.WriteUVarInt32(uint32(i))
+}
+
+// WriteVarInt writes a signed varint32 to the output (non zigzag).
+// int64 will be casted to int32, as it is minecraft largest type length.
+func (out *Output) WriteVarInt(i int64) {
+	out.WriteVarInt32(int32(i))
 }
 
 // WriteNullTerminatedString writes a null terminated string the the output.
@@ -106,7 +132,7 @@ func (out *Output) WriteNullTerminatedString(s string) {
 // WriteString writes a standard minecraft protocol string to the output.
 // It is a UTF-8 string prefixed with its size in bytes as an unsigned varint.
 func (out *Output) WriteString(s string) {
-	out.WriteUVarInt(uint64(len(s)))
+	out.WriteUVarInt32(uint32(len(s)))
 	out.WriteBytes([]byte(s))
 }
 

--- a/pkg/networking/output.go
+++ b/pkg/networking/output.go
@@ -90,10 +90,10 @@ func (out *Output) WriteUVarInt(i uint64) {
 	out.WriteBytes(uvarintBuf[:n])
 }
 
-// WriteVarInt64 writes a signed varint to the output.
+// WriteVarInt64 writes a signed varint to the output (non zigzag).
 func (out *Output) WriteVarInt(i int64) {
 	varintBuf := make([]byte, binary.MaxVarintLen64)
-	n := binary.PutVarint(varintBuf, int64(i))
+	n := binary.PutUvarint(varintBuf, uint64(i))
 	out.WriteBytes(varintBuf[:n])
 }
 

--- a/pkg/networking/output.go
+++ b/pkg/networking/output.go
@@ -2,6 +2,11 @@ package networking
 
 import "encoding/binary"
 
+const (
+	SEGMENT_BITS byte = 0x7F
+	CONTINUE_BIT byte = 0x80
+)
+
 // Output represents a connection output (i.e. what's written to the connection). It wraps several helpers to write to this output.
 type Output struct {
 	buf []byte
@@ -83,44 +88,37 @@ func (out *Output) WriteLittleEndianInt64(i uint64) {
 	out.WriteBytes(int64Buf)
 }
 
-// WriteUVarInt64 writes an unsigned varint to the output.
-func (out *Output) WriteUVarInt64(i uint64) {
-	uvarintBuf := make([]byte, binary.MaxVarintLen64)
-	n := binary.PutUvarint(uvarintBuf, uint64(i))
-	out.WriteBytes(uvarintBuf[:n])
+// WriteVarInt writes a varint to the output.
+func (out *Output) WriteVarInt(i int32) {
+	v := uint32(i)
+	for c := 0; c < 5; c++ {
+		currentByte := byte(v & uint32(SEGMENT_BITS))
+		v >>= 7
+		if v != 0 {
+			currentByte |= CONTINUE_BIT
+		}
+		out.WriteByte(currentByte)
+
+		if v == 0 {
+			return
+		}
+	}
 }
 
-// WriteVarInt64 writes a signed varint to the output (non zigzag).
-func (out *Output) WriteVarInt64(i int64) {
-	varintBuf := make([]byte, binary.MaxVarintLen64)
-	n := binary.PutUvarint(varintBuf, uint64(i))
-	out.WriteBytes(varintBuf[:n])
-}
-
-// WriteUVarInt32 writes an unsigned varint to the output.
-func (out *Output) WriteUVarInt32(i uint32) {
-	uvarintBuf := make([]byte, binary.MaxVarintLen32)
-	n := binary.PutUvarint(uvarintBuf, uint64(i))
-	out.WriteBytes(uvarintBuf[:n])
-}
-
-// WriteVarInt32 writes a signed varint to the output (non zigzag).
-func (out *Output) WriteVarInt32(i int32) {
-	varintBuf := make([]byte, binary.MaxVarintLen32)
-	n := binary.PutUvarint(varintBuf, uint64(i))
-	out.WriteBytes(varintBuf[:n])
-}
-
-// WriteUVarInt writes an unsigned varint32 to the output.
-// uint64 will be casted to uint32, as it is minecraft largest type length.
-func (out *Output) WriteUVarInt(i uint64) {
-	out.WriteUVarInt32(uint32(i))
-}
-
-// WriteVarInt writes a signed varint32 to the output (non zigzag).
-// int64 will be casted to int32, as it is minecraft largest type length.
-func (out *Output) WriteVarInt(i int64) {
-	out.WriteVarInt32(int32(i))
+// WriteVarLong writes a varlong to the output.
+func (out *Output) WriteVarLong(i int64) {
+	v := uint64(i)
+	for c := 0; c < 10; c++ {
+		currentByte := byte(v & uint64(SEGMENT_BITS))
+		v >>= 7
+		if v != 0 {
+			currentByte |= CONTINUE_BIT
+		}
+		out.WriteByte(currentByte)
+		if v == 0 {
+			return
+		}
+	}
 }
 
 // WriteNullTerminatedString writes a null terminated string the the output.
@@ -132,7 +130,7 @@ func (out *Output) WriteNullTerminatedString(s string) {
 // WriteString writes a standard minecraft protocol string to the output.
 // It is a UTF-8 string prefixed with its size in bytes as an unsigned varint.
 func (out *Output) WriteString(s string) {
-	out.WriteUVarInt32(uint32(len(s)))
+	out.WriteVarInt(int32(len(s)))
 	out.WriteBytes([]byte(s))
 }
 

--- a/pkg/networking/output_test.go
+++ b/pkg/networking/output_test.go
@@ -315,7 +315,7 @@ func TestWriteVarInt(t *testing.T) {
 		1354872603950807649,
 	}
 	expectedValues := [][]byte{
-		{194, 233, 171, 166, 142, 221, 188, 205, 37},
+		{225, 244, 149, 147, 199, 174, 222, 230, 18},
 	}
 
 	var out Output

--- a/pkg/networking/output_test.go
+++ b/pkg/networking/output_test.go
@@ -1,6 +1,8 @@
 package networking
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestBytes(t *testing.T) {
 	inputs := [][]byte{
@@ -290,19 +292,39 @@ func TestWriteLittleEndianInt64(t *testing.T) {
 	}
 }
 
-func TestWriteUVarInt(t *testing.T) {
-	inputs := []uint64{
-		1354872603950807649,
+func TestWriteVarInt(t *testing.T) {
+	inputs := []int32{
+		0,
+		1,
+		2,
+		127,
+		128,
+		255,
+		25565,
+		2097151,
+		2147483647,
+		-1,
+		-2147483648,
 	}
 	expectedValues := [][]byte{
-		{225, 244, 149, 147, 199, 174, 222, 230, 18},
+		{0},
+		{1},
+		{2},
+		{127},
+		{128, 1},
+		{255, 1},
+		{221, 199, 1},
+		{255, 255, 127},
+		{255, 255, 255, 255, 7},
+		{255, 255, 255, 255, 15},
+		{128, 128, 128, 128, 8},
 	}
 
 	var out Output
 
 	for i := 0; i < len(inputs); i++ {
 		out = NewOutput()
-		out.WriteUVarInt(inputs[i])
+		out.WriteVarInt(inputs[i])
 
 		if !BytesEqual(out.buf, expectedValues[i]) {
 			t.Errorf("Value %d: Expected %v got %v.", i, expectedValues[i], out.buf)
@@ -310,19 +332,39 @@ func TestWriteUVarInt(t *testing.T) {
 	}
 }
 
-func TestWriteVarInt64(t *testing.T) {
+func TestWriteVarLong(t *testing.T) {
 	inputs := []int64{
-		1354872603950807649,
+		0,
+		1,
+		2,
+		127,
+		128,
+		255,
+		2147483647,
+		9223372036854775807,
+		-1,
+		-2147483648,
+		-9223372036854775808,
 	}
 	expectedValues := [][]byte{
-		{225, 244, 149, 147, 199, 174, 222, 230, 18},
+		{0},
+		{1},
+		{2},
+		{127},
+		{128, 1},
+		{255, 1},
+		{255, 255, 255, 255, 7},
+		{255, 255, 255, 255, 255, 255, 255, 255, 127},
+		{255, 255, 255, 255, 255, 255, 255, 255, 255, 1},
+		{128, 128, 128, 128, 248, 255, 255, 255, 255, 1},
+		{128, 128, 128, 128, 128, 128, 128, 128, 128, 1},
 	}
 
 	var out Output
 
 	for i := 0; i < len(inputs); i++ {
 		out = NewOutput()
-		out.WriteVarInt64(inputs[i])
+		out.WriteVarLong(inputs[i])
 
 		if !BytesEqual(out.buf, expectedValues[i]) {
 			t.Errorf("Value %d: Expected %v got %v.", i, expectedValues[i], out.buf)

--- a/pkg/networking/output_test.go
+++ b/pkg/networking/output_test.go
@@ -310,7 +310,7 @@ func TestWriteUVarInt(t *testing.T) {
 	}
 }
 
-func TestWriteVarInt(t *testing.T) {
+func TestWriteVarInt64(t *testing.T) {
 	inputs := []int64{
 		1354872603950807649,
 	}
@@ -322,7 +322,7 @@ func TestWriteVarInt(t *testing.T) {
 
 	for i := 0; i < len(inputs); i++ {
 		out = NewOutput()
-		out.WriteVarInt(inputs[i])
+		out.WriteVarInt64(inputs[i])
 
 		if !BytesEqual(out.buf, expectedValues[i]) {
 			t.Errorf("Value %d: Expected %v got %v.", i, expectedValues[i], out.buf)

--- a/pkg/ping/client.go
+++ b/pkg/ping/client.go
@@ -14,6 +14,7 @@ const (
 	UnknownProtocolVersion int32  = -1
 	HandshakePacketID      uint32 = 0
 	PingPacketID           uint32 = 1
+	NextStateStatus        uint32 = 1
 )
 
 var (
@@ -32,7 +33,7 @@ func generateHandshakeRequest(hostname string, port uint16) networking.Output {
 
 	out.WriteBigEndianInt16(port)
 
-	out.WriteVarInt(1)
+	out.WriteVarInt(int32(NextStateStatus))
 
 	return out
 }

--- a/pkg/ping/client.go
+++ b/pkg/ping/client.go
@@ -24,15 +24,15 @@ var (
 func generateHandshakeRequest(hostname string, port uint16) networking.Output {
 	out := networking.NewOutput()
 
-	out.WriteUVarInt(uint64(HandshakePacketID))
+	out.WriteVarInt(int32(HandshakePacketID))
 
-	out.WriteVarInt(int64(UnknownProtocolVersion))
+	out.WriteVarInt(int32(UnknownProtocolVersion))
 
 	out.WriteString(hostname)
 
 	out.WriteBigEndianInt16(port)
 
-	out.WriteUVarInt(1)
+	out.WriteVarInt(1)
 
 	return out
 }
@@ -41,7 +41,7 @@ func generateHandshakeRequest(hostname string, port uint16) networking.Output {
 func parseHandshakeResponse(in networking.Input) (*handshakeResponse, error) {
 	var hsRes handshakeResponse
 
-	length, err := in.ReadUVarInt()
+	length, err := in.ReadVarInt()
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func parseHandshakeResponse(in networking.Input) (*handshakeResponse, error) {
 	}
 	_in := networking.NewInput(bytes.NewReader(content))
 
-	packetID, err := _in.ReadUVarInt()
+	packetID, err := _in.ReadVarInt()
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func parseHandshakeResponse(in networking.Input) (*handshakeResponse, error) {
 func generatePingRequest() networking.Output {
 	out := networking.NewOutput()
 
-	out.WriteUVarInt(uint64(PingPacketID))
+	out.WriteVarInt(int32(PingPacketID))
 
 	out.WriteBigEndianInt64(uint64(time.Now().UnixMilli()))
 
@@ -93,7 +93,7 @@ func generatePingRequest() networking.Output {
 func parsePongResponse(in networking.Input) (*pongResponse, error) {
 	var pongRes pongResponse
 
-	length, err := in.ReadUVarInt()
+	length, err := in.ReadVarInt()
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func parsePongResponse(in networking.Input) (*pongResponse, error) {
 	}
 	_in := networking.NewInput(bytes.NewReader(content))
 
-	packetID, err := _in.ReadUVarInt()
+	packetID, err := _in.ReadVarInt()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ping/packets.go
+++ b/pkg/ping/packets.go
@@ -47,7 +47,7 @@ type pongResponse struct {
 func transformToPacket(out networking.Output) networking.Output {
 	var packetOut networking.Output = networking.NewOutput()
 
-	packetOut.WriteUVarInt(uint64(len(out.Bytes())))
+	packetOut.WriteVarInt(int32(len(out.Bytes())))
 	packetOut.WriteBytes(out.Bytes())
 
 	return packetOut
@@ -56,7 +56,7 @@ func transformToPacket(out networking.Output) networking.Output {
 // emptyPacket generates an empty packet ready to be sent.
 func emptyPacket(packetID uint32) networking.Output {
 	out := networking.NewOutput()
-	out.WriteUVarInt(uint64(packetID))
+	out.WriteVarInt(int32(packetID))
 	return transformToPacket(out)
 }
 


### PR DESCRIPTION
Until now, mcutils relied on using the stdlib's `ReadVarint` and `PutVarint` methods to compute protocol buffers varints.

But as we can read [here](https://minecraft.wiki/w/Java_Edition_protocol/VarInt_and_VarLong#:~:text=Protocol%20buffers%20have%203%20types,the%20maximum%20number%20of%20bytes.), Minecraft protocol uses non zigzag encoded signed varints so the implementation was wrong.

In fact, `networking.Output.WriteVarInt` is only used once to write the unknown protocol version, which is `-1` in the regular post-1.7 SLP. Most server implementations don't care about this data, and so the library worked as intended, but it has to be fixed for the sake of correctness.

The library should continue to work as previously, if not better.

This PR adds breaking changes to the `networking` package. I don't think anyone is using this besides `mcutils` itself (maybe it should have been an internal), so I won't make publish a major version for this. I clarified in the README the fact that semver compatibility promise excludes that one specific package.

`VarInt`s and `VarLong` now are better tested with official samples found on the [wiki](https://minecraft.wiki/w/Java_Edition_protocol/VarInt_and_VarLong).